### PR TITLE
Fix horde end time

### DIFF
--- a/DEV_NOTES.md
+++ b/DEV_NOTES.md
@@ -1,7 +1,7 @@
 # Times for reference
 In the game's console, use `settime` and `gettime` to test different times for 7d!time.
 
-At the time of writing, the horde starts at 22:00 on Day 7 and ends at 06:00 on Day 8.
+At the time of writing, the horde starts at 22:00 on Day 7 and ends at 04:00 on Day 8.
 
 ## Useful timestamps for testing
 * Day 5, 04:00 - 100000

--- a/index.js
+++ b/index.js
@@ -321,7 +321,7 @@ function handleTime(line, msg) {
   let hordeMsg = "";
 
   const isFirstWeek = day === 1 || day === 2;
-  const isHordeHour = (daysFromHorde === 0 && hour >= 22) || (daysFromHorde === 1 && hour < 6);
+  const isHordeHour = (daysFromHorde === 0 && hour >= 22) || (daysFromHorde === 1 && hour < 4);
 
   const isHordeNow = !isFirstWeek && isHordeHour;
 


### PR DESCRIPTION
I noticed that the bot reports the horde is rampaging for two hours longer than it should be.  The default is for the horde to be from 22:00 until 04:00 on the following morning, but the bot thinks the horde runs until 06:00.  

It might be better to read the end hour for the night from the config file similar to how it reads the blood moon frequency, but that's a bigger change I don't have the time to make or test right now.  